### PR TITLE
.github: add go specific workflows

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,32 @@
+# The following workflow will only run when a pull request is made that includes
+# a change to a Go (*.go) file, or when its pushed into main.
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main 
+  pull_request:
+    paths:
+      - '**.go'
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: Golangci Linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v4
+
+      - name: Set Up Golang 
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Golangci-Lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64

--- a/.github/workflows/gotidy-check.yml
+++ b/.github/workflows/gotidy-check.yml
@@ -1,0 +1,25 @@
+# The following workflow will only run when a pull request is made that includes
+# a change to a Go (*.go) file, or when its pushed into main.
+name: go-tidy-check
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '**.go'
+
+jobs:
+  build:
+    name: Go Mod Tidy Check
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Repostiry Checkout
+        uses: actions/checkout@v4
+
+      - name: Set Up Golang
+        uses: actions/setup-go@v4 # Go must be at least version 1.21
+      
+      - name: Go Mod Tidy Check
+        uses: katexochen/go-tidy-check@v2

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,6 +1,6 @@
 # The following workflow will only run when a pull request is made that includes
-# a change to a Markdown (*.md) file.
-name: Markdown linter
+# a change to a Markdown (*.md) file or when is pushed into main.
+name: markdown-lint
 on:
   push:
     branches:
@@ -22,10 +22,7 @@ jobs:
       # To report GitHub Actions status checks
       statuses: write
   
-    steps:
-    - name: Markdown linter
-      run: echo "Running a linter action for Markdown 🚀"
-    
+    steps: 
     - name: Repository checkout
       uses: actions/checkout@v4
       with:


### PR DESCRIPTION
This PR adds two go specific workflows which apply go common linters as well as checking if the `go.mod` file is correct. Additionally some format issues where solved with the previous actions.