### PR TITLE
exchange: add a `table.model`

### DIFF
--- a/cmd/currency-converter/main.go
+++ b/cmd/currency-converter/main.go
@@ -35,6 +35,4 @@ func main() {
 		fmt.Printf("%s\n", ffhelp.Command(cmd))
 		return
 	}
-
-	logger.Info("Thanks For Using The Currency Converter.")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,14 +3,15 @@ module github.com/TelmoMtzLarrinaga/currency-converter
 go 1.24.0
 
 require (
+	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4
+	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/peterbourgon/ff/v4 v4.0.0-alpha.4
 	go.uber.org/zap v1.27.0
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/lipgloss v1.0.0 // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,17 @@
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/aymanbagabas/go-udiff v0.2.0 h1:TK0fH4MteXUDspT88n8CKzvK0X9O2xu9yQjWpi6yML8=
+github.com/aymanbagabas/go-udiff v0.2.0/go.mod h1:RE4Ex0qsGkTAJoQdQQCA0uG+nAzJO/pI/QwceO5fgrA=
+github.com/charmbracelet/bubbles v0.20.0 h1:jSZu6qD8cRQ6k9OMfR1WlM+ruM8fkPWkHvQWD9LIutE=
+github.com/charmbracelet/bubbles v0.20.0/go.mod h1:39slydyswPy+uVOHZ5x/GjwVAFkCsV8IIVy+4MhzwwU=
 github.com/charmbracelet/bubbletea v1.3.4 h1:kCg7B+jSCFPLYRA52SDZjr51kG/fMUEoPoZrkaDHyoI=
 github.com/charmbracelet/bubbletea v1.3.4/go.mod h1:dtcUCyCGEX3g9tosuYiut3MXgY/Jsv9nKVdibKKRRXo=
 github.com/charmbracelet/lipgloss v1.0.0 h1:O7VkGDvqEdGi93X+DeqsQ7PKHDgtQfF8j8/O2qFMQNg=
 github.com/charmbracelet/lipgloss v1.0.0/go.mod h1:U5fy9Z+C38obMs+T+tJqst9VGzlOYGj4ri9reL3qUlo=
 github.com/charmbracelet/x/ansi v0.8.0 h1:9GTq3xq9caJW8ZrBTe0LIe2fvfLR/bYXKTx2llXn7xE=
 github.com/charmbracelet/x/ansi v0.8.0/go.mod h1:wdYl/ONOLHLIVmQaxbIYEC/cRKOQyjTkowiI4blgS9Q=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b h1:MnAMdlwSltxJyULnrYbkZpp4k58Co7Tah3ciKhSNo0Q=
+github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQaGIAQ=
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/internal/exchange/exchange.go
+++ b/internal/exchange/exchange.go
@@ -1,6 +1,8 @@
 package exchange
 
 import (
+	"github.com/charmbracelet/bubbles/help"
+	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"go.uber.org/zap"
 )
@@ -8,41 +10,64 @@ import (
 // model will store our applications state.
 type model struct {
 	logger *zap.Logger
+	table  table.Model
+	keys   keyMap
+	help   help.Model
 }
 
 // Init is the first function that will be called. It can return an optional
 // initial command or return nil if an initial command is not required.
-func (m model) Init() tea.Cmd {
-	// No I/O as of now
-	return nil
-}
+func (m model) Init() tea.Cmd { return nil }
 
 // Update is called when a message is received. The message will be inspected
 // and, in response, the model will be updated and a command will be send.
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		// If we set a width on the help menu it can gracefully truncate
+		// its view as needed.
+		m.help.Width = msg.Width
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "esc":
+			if m.table.Focused() {
+				m.table.Blur()
+			} else {
+				m.table.Focus()
+			}
 		// Quit currency-converter programn
 		case "q":
 			return m, tea.Quit
+		// Help with key bindings
+		case "?":
+			m.help.ShowAll = !m.help.ShowAll
 		// Show currency-converter programn
-		case "enter", " ":
+		case " ":
+			return m, tea.Batch(
+				tea.Println("This is a test return."),
+			)
 		}
 	}
+	m.table, cmd = m.table.Update(msg)
 	// Return the updated model to the Bubble Tea runtime for processing.
-	return m, nil
+	return m, cmd
 }
 
 // View renders the program's UI, which is just a string. The view is rendered
 // after every Update.
 func (m model) View() string {
-	return ""
+	helpView := m.help.View(m.keys)
+	return baseStyle.Render(m.table.View() + "\n\n" + helpView)
 }
 
 // We will define our applications initial state which is just a
 func InitialModel(cfg *Config) model {
 	return model{
 		logger: cfg.Logger,
+		table:  newTable(),
+		keys:   keys,
+		help:   help.New(),
 	}
 }

--- a/internal/exchange/help.go
+++ b/internal/exchange/help.go
@@ -1,0 +1,56 @@
+package exchange
+
+import "github.com/charmbracelet/bubbles/key"
+
+// keyMap defines a set of keybindings. To work for help it must satisfy
+// key.Map. It could also very easily be a map[string]key.Binding.
+type keyMap struct {
+	Up    key.Binding
+	Down  key.Binding
+	Left  key.Binding
+	Right key.Binding
+	Help  key.Binding
+	Quit  key.Binding
+}
+
+// ShortHelp returns keybindings to be shown in the mini help view. It's part
+// of the key.Map interface.
+func (k keyMap) ShortHelp() []key.Binding {
+	return []key.Binding{k.Help, k.Quit}
+}
+
+// FullHelp returns keybindings for the expanded help view. It's part of the
+// key.Map interface.
+func (k keyMap) FullHelp() [][]key.Binding {
+	return [][]key.Binding{
+		{k.Up, k.Down, k.Left, k.Right}, // first column
+		{k.Help, k.Quit},                // second column
+	}
+}
+
+var keys = keyMap{
+	Up: key.NewBinding(
+		key.WithKeys("up", "k"),
+		key.WithHelp("↑/k", "move up"),
+	),
+	Down: key.NewBinding(
+		key.WithKeys("down", "j"),
+		key.WithHelp("↓/j", "move down"),
+	),
+	Left: key.NewBinding(
+		key.WithKeys("left", "h"),
+		key.WithHelp("←/h", "move left"),
+	),
+	Right: key.NewBinding(
+		key.WithKeys("right", "l"),
+		key.WithHelp("→/l", "move right"),
+	),
+	Help: key.NewBinding(
+		key.WithKeys("?"),
+		key.WithHelp("?", "toggle help"),
+	),
+	Quit: key.NewBinding(
+		key.WithKeys("q", "esc", "ctrl+c"),
+		key.WithHelp("q", "quit"),
+	),
+}

--- a/internal/exchange/table.go
+++ b/internal/exchange/table.go
@@ -1,0 +1,48 @@
+package exchange
+
+import (
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/lipgloss"
+)
+
+var baseStyle = lipgloss.NewStyle().
+	BorderStyle(lipgloss.NormalBorder()).
+	BorderForeground(lipgloss.Color("#c2f2d0")) // * #c2f2d0
+
+var columns []table.Column = []table.Column{
+	{Title: "COUNTRY", Width: 10},
+	{Title: "CURRENCY", Width: 15},
+	{Title: "UNIT", Width: 5},
+}
+
+var rows []table.Row = []table.Row{
+	{"United States", "The Dollar", "$"},
+	{"Japan", "Japanese Yen", "¥"},
+	{"Spain", "Euro", "€"},
+	{"England", "Pound Sterling", "£"},
+}
+
+// newTable returns a bubbletea table model with a custom format.
+func newTable() table.Model {
+	t := table.New(
+		table.WithColumns(columns),
+		table.WithRows(rows),
+		table.WithHeight(5),
+		table.WithFocused(true),
+		table.WithKeyMap(table.DefaultKeyMap()),
+	)
+
+	s := table.DefaultStyles()
+	s.Header = s.Header.
+		BorderStyle(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("#97ebdb")). // * #97ebdb
+		BorderBottom(true).
+		Bold(true)
+	s.Selected = s.Selected.
+		Foreground(lipgloss.Color("#00c2c7")). // * #daf8e3
+		Background(lipgloss.Color("#daf8e3")). // * #00c2c7
+		Bold(false)
+	t.SetStyles(s)
+
+	return t
+}


### PR DESCRIPTION
This PR adds a first implementation of a bubbletea `table.model`. It uses the default style with no custom formatting or anything else. It also adds a small help menu for the key bindings.