### PR TITLE
exchange: add `selecteRow` and quantity flag

### DIFF
--- a/internal/cli/currency-converter.go
+++ b/internal/cli/currency-converter.go
@@ -53,7 +53,8 @@ func newExchangeSubcommand() *ff.Command {
 
 	// define the flags under exchange subcommand
 	_ = fs.StringLong("config", "cc.config", "Config file (optional)")
-	fs.BoolVarDefault(&cfg.Debug, '0', "debug", false, "Debug log level")
+	fs.BoolVarDefault(&cfg.Debug, 'd', "debug", false, "Debug log level")
+	fs.Float64Var(&cfg.Quantity, 'q', "quantity", 0, "Quantity to convert to: [$,¥,€,£]")
 
 	return &ff.Command{
 		Name:      "exchange",

--- a/internal/exchange/config.go
+++ b/internal/exchange/config.go
@@ -3,8 +3,9 @@ package exchange
 import "go.uber.org/zap"
 
 type Config struct {
-	Logger *zap.Logger
-	Debug  bool
+	Logger   *zap.Logger
+	Debug    bool
+	Quantity float64
 }
 
 func NewExchangeConfig() *Config {

--- a/internal/exchange/exchange.go
+++ b/internal/exchange/exchange.go
@@ -9,10 +9,12 @@ import (
 
 // model will store our applications state.
 type model struct {
-	logger *zap.Logger
-	table  table.Model
-	keys   keyMap
-	help   help.Model
+	logger   *zap.Logger
+	table    table.Model
+	keys     keyMap
+	help     help.Model
+	quantity float64
+	quote    table.Row
 }
 
 // Init is the first function that will be called. It can return an optional
@@ -45,8 +47,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.help.ShowAll = !m.help.ShowAll
 		// Show currency-converter programn
 		case " ":
+			m.quote = m.table.SelectedRow()
 			return m, tea.Batch(
-				tea.Println("This is a test return."),
+				tea.Println(m.quote, m.quantity),
 			)
 		}
 	}
@@ -65,9 +68,10 @@ func (m model) View() string {
 // We will define our applications initial state which is just a
 func InitialModel(cfg *Config) model {
 	return model{
-		logger: cfg.Logger,
-		table:  newTable(),
-		keys:   keys,
-		help:   help.New(),
+		logger:   cfg.Logger,
+		table:    newTable(),
+		keys:     keys,
+		help:     help.New(),
+		quantity: cfg.Quantity,
 	}
 }

--- a/internal/exchange/help.go
+++ b/internal/exchange/help.go
@@ -5,18 +5,19 @@ import "github.com/charmbracelet/bubbles/key"
 // keyMap defines a set of keybindings. To work for help it must satisfy
 // key.Map. It could also very easily be a map[string]key.Binding.
 type keyMap struct {
-	Up    key.Binding
-	Down  key.Binding
-	Left  key.Binding
-	Right key.Binding
-	Help  key.Binding
-	Quit  key.Binding
+	Up     key.Binding
+	Down   key.Binding
+	Left   key.Binding
+	Right  key.Binding
+	Select key.Binding
+	Help   key.Binding
+	Quit   key.Binding
 }
 
 // ShortHelp returns keybindings to be shown in the mini help view. It's part
 // of the key.Map interface.
 func (k keyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Help, k.Quit}
+	return []key.Binding{k.Select, k.Help, k.Quit}
 }
 
 // FullHelp returns keybindings for the expanded help view. It's part of the
@@ -24,7 +25,7 @@ func (k keyMap) ShortHelp() []key.Binding {
 func (k keyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.Left, k.Right}, // first column
-		{k.Help, k.Quit},                // second column
+		{k.Select, k.Help, k.Quit},      // second column
 	}
 }
 
@@ -44,6 +45,10 @@ var keys = keyMap{
 	Right: key.NewBinding(
 		key.WithKeys("right", "l"),
 		key.WithHelp("→/l", "move right"),
+	),
+	Select: key.NewBinding(
+		key.WithKeys(" "),
+		key.WithHelp("spc", "select"),
 	),
 	Help: key.NewBinding(
 		key.WithKeys("?"),

--- a/internal/exchange/table.go
+++ b/internal/exchange/table.go
@@ -10,7 +10,7 @@ var baseStyle = lipgloss.NewStyle().
 	BorderForeground(lipgloss.Color("#c2f2d0")) // * #c2f2d0
 
 var columns []table.Column = []table.Column{
-	{Title: "COUNTRY", Width: 10},
+	{Title: "COUNTRY", Width: 15},
 	{Title: "CURRENCY", Width: 15},
 	{Title: "UNIT", Width: 5},
 }


### PR DESCRIPTION
This PR adds the `selecteRow` functionality as well as a quantity flag. The `selecteRow` is able to provide the whole table row and the quantity flag stores in the model a desired quantity to be converted to another currency. Additionally, a new key binding was added to the help `?`.